### PR TITLE
feat: OPTIC-3: Enable users to submit and pause their lead time by returning to the dm list

### DIFF
--- a/src/sdk/lsf-sdk.js
+++ b/src/sdk/lsf-sdk.js
@@ -25,7 +25,6 @@ import {
 import { isDefined } from "../utils/utils";
 import { Modal } from "../components/Common/Modal/Modal";
 import { CommentsSdk } from "./comments-sdk";
-import { getRoot } from "mobx-state-tree";
 // import { LSFHistory } from "./lsf-history";
 import { annotationToServer, taskToLSFormat } from "./lsf-utils";
 
@@ -303,9 +302,7 @@ export class LSFWrapper {
   }
 
   exitStream() {
-    const view = this.datamanager.store.viewsStore.selected;
-
-    return getRoot(view).closeLabeling();
+    window.LSH.push("/projects");
   }
 
   selectTask(task, annotationID, fromHistory = false) {
@@ -561,7 +558,7 @@ export class LSFWrapper {
         { errorHandler: result => result.status === 409 },
       );
     }, false, loadNext);
-    if (exitStream) this.exitStream();
+    if (exitStream) this.exitStream(); 
   };
 
   /** @private */
@@ -589,7 +586,7 @@ export class LSFWrapper {
 
     this.datamanager.invoke("updateAnnotation", ls, annotation, result);
 
-    if (exitStream) this.exitStream();
+    if (exitStream) return  this.exitStream();
 
     const isRejectedQueue = isDefined(task.default_selected_annotation);
 

--- a/src/sdk/lsf-sdk.js
+++ b/src/sdk/lsf-sdk.js
@@ -550,13 +550,16 @@ export class LSFWrapper {
     const loadNext = exitStream ? false : this.shouldLoadNext();
     
     await this.submitCurrentAnnotation("submitAnnotation", async (taskID, body) => {
-      return await this.datamanager.apiCall(
+      const submit = await this.datamanager.apiCall(
         "submitAnnotation",
         { taskID },
         { body },
         // don't react on duplicated annotations error
         { errorHandler: result => result.status === 409 },
-      ).then(() => { if (exitStream) this.exitStream(); });
+      );
+
+      if (exitStream) return this.exitStream();
+      return submit;
     }, false, loadNext);
     
   };


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change
An option submit/update and exit the stream to stop lead time from running on


#### What does this fix?
feature


#### What is the new behavior?
you are able to submit and not load another task and instead return to the datamanager list

#### What is the current behavior?
if you want to take a break you would have to close the window

#### What libraries were added/updated?
N/A


#### Does this change affect performance?
no


#### Does this change affect security?
no


#### What alternative approaches were there?
There are likely numerous methods for passing information to the LSF SDK. However, since we were already utilizing query parameters in the 'submit' function, it made sense to continue using this approach for passing a temporary flag to the SDK. This method is convenient because it avoids interfering with the existing chain of functions that have been scaffolded between the two stores.


#### What feature flags were used to cover this change?



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_

