### PR TITLE
chore: Fix "Conflicting values" during build

### DIFF
--- a/webpack.config-builder.js
+++ b/webpack.config-builder.js
@@ -11,12 +11,12 @@ const workingDirectory = process.env.WORK_DIR
   : path.resolve(__dirname, "build");
 
 if (workingDirectory) {
-  console.log(`Working directory set as ${workingDirectory}`)
+  console.log(`Working directory set as ${workingDirectory}`);
 }
 
 const customDistDir = !!process.env.WORK_DIR;
 
-const DEFAULT_NODE_ENV = process.env.BUILD_MODULE ? 'production' : (process.env.NODE_ENV || 'development')
+const DEFAULT_NODE_ENV = process.env.BUILD_MODULE ? 'production' : (process.env.NODE_ENV || 'development');
 
 const isDevelopment = DEFAULT_NODE_ENV !== "production";
 
@@ -67,7 +67,7 @@ const optimizer = () => {
       new CssMinimizerPlugin({
         parallel: true,
       }),
-    )
+    );
   }
 
   if (BUILD.NO_MINIMIZE) {
@@ -77,7 +77,7 @@ const optimizer = () => {
 
   if (BUILD.NO_CHUNKS) {
     result.runtimeChunk = false;
-    result.splitChunks = { cacheGroups: { default: false } }
+    result.splitChunks = { cacheGroups: { default: false } };
   }
 
   return result;
@@ -129,7 +129,7 @@ const babelLoader = {
   options: {
     presets: [
       ["@babel/preset-react", {
-        "runtime": "automatic"
+        "runtime": "automatic",
       }],
       "@babel/preset-typescript",
       [
@@ -190,12 +190,12 @@ const devServer = () => {
       hot: true,
       port: 9000,
       static: {
-        directory: path.join(__dirname, "public")
+        directory: path.join(__dirname, "public"),
       },
       historyApiFallback: {
         index: "./public/index.html",
       },
-    }
+    },
   } : {};
 };
 
@@ -233,7 +233,7 @@ module.exports = ({ withDevServer = false } = {}) => ({
   ...(withDevServer ? devServer() : {}),
   entry: {
     main: [
-      path.resolve(__dirname, "src/index.js")
+      path.resolve(__dirname, "src/index.js"),
     ],
   },
   output: {

--- a/webpack.config-builder.js
+++ b/webpack.config-builder.js
@@ -5,7 +5,6 @@ const webpack = require("webpack");
 const Dotenv = require("dotenv-webpack");
 const TerserPlugin = require("terser-webpack-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
-const { EnvironmentPlugin } = require("webpack");
 
 const workingDirectory = process.env.WORK_DIR
   ? path.resolve(__dirname, process.env.WORK_DIR)
@@ -38,7 +37,6 @@ const LOCAL_ENV = {
   NODE_ENV: DEFAULT_NODE_ENV,
   BUILD_NO_SERVER: BUILD.NO_SERVER,
   CSS_PREFIX: "dm-",
-  API_GATEWAY: "http://localhost:8081/api/dm",
   LS_ACCESS_TOKEN: "",
 };
 
@@ -208,7 +206,6 @@ const plugins = [
     allowEmptyValues: true,
     defaults: "./.env.defaults",
   }),
-  new EnvironmentPlugin(LOCAL_ENV),
   new MiniCssExtractPlugin({
     ...cssOutput(),
   }),


### PR DESCRIPTION
`EnvironmentPlugin` was used twice, plus `API_GATEWAY` is already in [.env.defaults](https://github.com/HumanSignal/dm2/blob/master/.env.defaults).
Webpack is complaining about this during build, because those values are different. So I left it only to be in ENV vars, not to be set directly in webpack config.

<img width="496" alt="screenshot-dm-build-error" src="https://github.com/HumanSignal/dm2/assets/1607227/9de2d9bc-90f3-405c-a4b3-52872e049d39">
