### PR TITLE
fix: OPTIC-109: Blank draft should not be created when an annotation is submitted

### DIFF
--- a/src/sdk/lsf-sdk.js
+++ b/src/sdk/lsf-sdk.js
@@ -642,7 +642,7 @@ export class LSFWrapper {
 
   saveDraft = async (target = null) => {
     const selected = target || this.lsf?.annotationStore?.selected;
-    const hasChanges = !!selected?.history.undoIdx;
+    const hasChanges = !!selected?.history.undoIdx && !selected?.submissionStarted;
 
     if (!hasChanges || !selected) return;
     const res = await selected?.saveDraftImmediatelyWithResults();

--- a/src/sdk/lsf-sdk.js
+++ b/src/sdk/lsf-sdk.js
@@ -649,7 +649,7 @@ export class LSFWrapper {
     const status = res?.$meta?.status;
 
     if (status === 200 || status === 201) return this.datamanager.invoke("toast", { message: "Draft saved successfully", type: "info" });
-    else return this.datamanager.invoke("toast", { message: "There was an error saving your draft", type: "error" });
+    else if (status !== undefined) return this.datamanager.invoke("toast", { message: "There was an error saving your draft", type: "error" });
   };
   
   onSubmitDraft = async (studio, annotation, params = {}) => {

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -550,10 +550,14 @@ export const AppStore = types
         }
 
         if (result.response) {
-          self.serverError.set(methodName, {
-            error: "Something went wrong",
-            response: result.response,
-          });
+          try {
+            self.serverError.set(methodName, {
+              error: "Something went wrong",
+              response: result.response,
+            });
+          } catch {
+            // ignore
+          }
         }
 
         console.warn({
@@ -568,7 +572,11 @@ export const AppStore = types
         //   description: result?.response?.detail ?? result.error,
         // });
       } else {
-        self.serverError.delete(methodName);
+        try {
+          self.serverError.delete(methodName);
+        } catch {
+          // ignore
+        }
       }
 
       return result;


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change
To help keep more control with the annotator's workflow we are going to be offering more aggressive draft saving, and notification of this. However it was identified that this would have introduced a regression with regards to creating a blank draft in doing so, and thus this fix is required to allow this functionality to be enabled in full.



#### What feature flags were used to cover this change?
- `fflag_feat_optic_2_ensure_draft_saved_short`



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
LabelStream, QuickView