### PR TITLE
fix: DIA-667: [FE] semantic search empty state when no results exist with in selected threshold

### DIFF
--- a/src/components/MainView/DataView/DataView.js
+++ b/src/components/MainView/DataView/DataView.js
@@ -16,6 +16,7 @@ import { Tooltip } from "../../Common/Tooltip/Tooltip";
 import { GridView } from "../GridView/GridView";
 import "./DataView.styl";
 import { Button } from "../../Common/Button/Button";
+import { useEffect } from "react";
 
 const injector = inject(({ store }) => {
   const { dataStore, currentView } = store;
@@ -58,6 +59,7 @@ export const DataView = injector(
     isLocked,
     ...props
   }) => {
+    const [datasetStatusID, setDatasetStatusID] = useState(store.SDK.dataset?.status?.id);
     const [currentPageSize, setPageSize] = useState(getStoredPageSize("tasks", DEFAULT_PAGE_SIZE));
 
     const setPage = useCallback((page, pageSize) => {
@@ -141,7 +143,7 @@ export const DataView = injector(
             <Spinner size="large" />
           </Block>
         );
-      } else if (store.SDK.type === 'DE' && store.SDK.dataset?.status?.id === 'failed') {
+      } else if (store.SDK.type === 'DE' && datasetStatusID === 'failed') {
         return (
           <Block name="syncInProgress">
             <Elem name='title' tag="h3">Failed to sync data</Elem>
@@ -319,6 +321,15 @@ export const DataView = injector(
 
       if (highlighted && !highlighted.isSelected) store.startLabeling(highlighted);
     });
+
+    useEffect(() => {
+      const updateDatasetStatus = (dataset) => (
+        dataset?.status?.id && setDatasetStatusID(dataset?.status?.id)
+      );
+
+      getRoot(store).SDK.on("datasetUpdated", updateDatasetStatus);
+      return () => getRoot(store).SDK.off("datasetUpdated", updateDatasetStatus);
+    }, []);
 
     // Render the UI for the table
     return (

--- a/src/components/MainView/DataView/DataView.js
+++ b/src/components/MainView/DataView/DataView.js
@@ -141,7 +141,17 @@ export const DataView = injector(
             <Spinner size="large" />
           </Block>
         );
-      } else if (store.SDK.type === 'DE' && (total === 0 || !hasData)) {
+      } else if (store.SDK.type === 'DE' && store.SDK.dataset?.status?.id === 'failed') {
+        return (
+          <Block name="syncInProgress">
+            <Elem name='title' tag="h3">Failed to sync data</Elem>
+            <Elem name='text'>Check your storage settings and resync to import records</Elem>
+            <Button onClick={async () => {
+              window.open('./settings/storage');
+            }}>Manage Storage</Button>
+          </Block>
+        );
+      } else if (store.SDK.type === 'DE' && (total === 0 || data.length === 0 || !hasData)) {
         return (
           <Block name="syncInProgress">
             <Elem name='title' tag="h3">Hang tight! Items are syncing in the background</Elem>

--- a/src/components/MainView/DataView/DataView.js
+++ b/src/components/MainView/DataView/DataView.js
@@ -4,7 +4,7 @@ import { useCallback, useMemo, useState } from "react";
 import { FaQuestionCircle } from "react-icons/fa";
 import { useShortcut } from "../../../sdk/hotkeys";
 import { Block, Elem } from "../../../utils/bem";
-import { FF_DEV_2536, FF_DEV_4008, FF_OPTIC_2, isFF } from '../../../utils/feature-flags';
+import { FF_DEV_2536, FF_DEV_4008, FF_LOPS_86, FF_OPTIC_2, isFF } from '../../../utils/feature-flags';
 import * as CellViews from "../../CellViews";
 import { Icon } from "../../Common/Icon/Icon";
 import { DEFAULT_PAGE_SIZE, getStoredPageSize, Pagination, setStoredPageSize } from "../../Common/Pagination/Pagination";
@@ -147,10 +147,16 @@ export const DataView = injector(
         return (
           <Block name="syncInProgress">
             <Elem name='title' tag="h3">Failed to sync data</Elem>
-            <Elem name='text'>Check your storage settings and resync to import records</Elem>
-            <Button onClick={async () => {
-              window.open('./settings/storage');
-            }}>Manage Storage</Button>
+            {isFF(FF_LOPS_86) ? (
+              <>
+                <Elem name='text'>Check your storage settings and resync to import records</Elem>
+                <Button onClick={async () => {
+                  window.open('./settings/storage');
+                }}>Manage Storage</Button>
+              </>
+            ) : (
+              <Elem name='text'>Check your storage settings. You may need to recreate this dataset</Elem>
+            )}
           </Block>
         );
       } else if (store.SDK.type === 'DE' && (total === 0 || data.length === 0 || !hasData) && datasetStatusID === 'completed') {

--- a/src/components/MainView/DataView/DataView.js
+++ b/src/components/MainView/DataView/DataView.js
@@ -143,7 +143,7 @@ export const DataView = injector(
             <Spinner size="large" />
           </Block>
         );
-      } else if (store.SDK.type === 'DE' && datasetStatusID === 'failed') {
+      } else if (store.SDK.type === 'DE' && ['canceled', 'failed'].includes(datasetStatusID)) {
         return (
           <Block name="syncInProgress">
             <Elem name='title' tag="h3">Failed to sync data</Elem>
@@ -151,6 +151,13 @@ export const DataView = injector(
             <Button onClick={async () => {
               window.open('./settings/storage');
             }}>Manage Storage</Button>
+          </Block>
+        );
+      } else if (store.SDK.type === 'DE' && (total === 0 || data.length === 0 || !hasData) && datasetStatusID === 'completed') {
+        return (
+          <Block name="syncInProgress">
+            <Elem name='title' tag="h3">Nothing found</Elem>
+            <Elem name='text'>Try adjusting the filter or semantic search parameters</Elem>
           </Block>
         );
       } else if (store.SDK.type === 'DE' && (total === 0 || data.length === 0 || !hasData)) {

--- a/src/components/MainView/DataView/DataView.js
+++ b/src/components/MainView/DataView/DataView.js
@@ -157,7 +157,7 @@ export const DataView = injector(
         return (
           <Block name="syncInProgress">
             <Elem name='title' tag="h3">Nothing found</Elem>
-            <Elem name='text'>Try adjusting the filter or semantic search parameters</Elem>
+            <Elem name='text'>Try adjusting the filter or similarity search parameters</Elem>
           </Block>
         );
       } else if (store.SDK.type === 'DE' && (total === 0 || data.length === 0 || !hasData)) {

--- a/src/components/MainView/DataViewOld/Table.js
+++ b/src/components/MainView/DataViewOld/Table.js
@@ -137,7 +137,17 @@ export const DataView = injector(
               <Spinner size="large" />
             </Block>
           );
-        } else if (store.SDK.type === 'DE' && (total === 0 || !hasData)) {
+        } else if (store.SDK.type === 'DE' && store.SDK.dataset?.status?.id === 'failed') {
+          return (
+            <Block name="syncInProgress">
+              <Elem name='title' tag="h3">Failed to sync data</Elem>
+              <Elem name='text'>Check your storage settings and resync to import records</Elem>
+              <Button onClick={async () => {
+                window.open('./settings/storage');
+              }}>Manage Storage</Button>
+            </Block>
+          );
+        } else if (store.SDK.type === 'DE' && (total === 0 || data.length === 0 || !hasData)) {
           return (
             <Block name="syncInProgress">
               <Elem name='title' tag="h3">Hang tight! Items are syncing in the background</Elem>

--- a/src/components/MainView/DataViewOld/Table.js
+++ b/src/components/MainView/DataViewOld/Table.js
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from "react";
 import { FaQuestionCircle } from "react-icons/fa";
 import { useShortcut } from "../../../sdk/hotkeys";
 import { Block, Elem } from "../../../utils/bem";
-import { FF_DEV_2536, FF_DEV_4008, FF_OPTIC_2, isFF } from '../../../utils/feature-flags';
+import { FF_DEV_2536, FF_DEV_4008, FF_LOPS_86, FF_OPTIC_2, isFF } from '../../../utils/feature-flags';
 import * as CellViews from "../../CellViews";
 import { Icon } from "../../Common/Icon/Icon";
 import { ImportButton } from "../../Common/SDKButtons";
@@ -144,10 +144,16 @@ export const DataView = injector(
           return (
             <Block name="syncInProgress">
               <Elem name='title' tag="h3">Failed to sync data</Elem>
-              <Elem name='text'>Check your storage settings and resync to import records</Elem>
-              <Button onClick={async () => {
-                window.open('./settings/storage');
-              }}>Manage Storage</Button>
+              {isFF(FF_LOPS_86) ? (
+                <>
+                  <Elem name='text'>Check your storage settings and resync to import records</Elem>
+                  <Button onClick={async () => {
+                    window.open('./settings/storage');
+                  }}>Manage Storage</Button>
+                </>
+              ) : (
+                <Elem name='text'>Check your storage settings. You may need to recreate this dataset</Elem>
+              )}
             </Block>
           );
         } else if (store.SDK.type === 'DE' && (total === 0 || data.length === 0 || !hasData) && datasetStatusID === 'completed') {

--- a/src/components/MainView/DataViewOld/Table.js
+++ b/src/components/MainView/DataViewOld/Table.js
@@ -154,7 +154,7 @@ export const DataView = injector(
           return (
             <Block name="syncInProgress">
               <Elem name='title' tag="h3">Nothing found</Elem>
-              <Elem name='text'>Try adjusting the filter or semantic search parameters</Elem>
+              <Elem name='text'>Try adjusting the filter or similarity search parameters</Elem>
             </Block>
           );
         } else if (store.SDK.type === 'DE' && (total === 0 || data.length === 0 || !hasData)) {

--- a/src/components/MainView/DataViewOld/Table.js
+++ b/src/components/MainView/DataViewOld/Table.js
@@ -15,6 +15,8 @@ import { Tooltip } from "../../Common/Tooltip/Tooltip";
 import { GridView } from "../GridViewOld/GridView";
 import "./Table.styl";
 import { Button } from "../../Common/Button/Button";
+import { useState } from "react";
+import { useEffect } from "react";
 
 const injector = inject(({ store }) => {
   const { dataStore, currentView } = store;
@@ -57,6 +59,7 @@ export const DataView = injector(
     isLocked,
     ...props
   }) => {
+    const [datasetStatusID, setDatasetStatusID] = useState(store.SDK.dataset?.status?.id);
     const focusedItem = useMemo(() => {
       return props.focusedItem;
     }, [props.focusedItem]);
@@ -137,7 +140,7 @@ export const DataView = injector(
               <Spinner size="large" />
             </Block>
           );
-        } else if (store.SDK.type === 'DE' && store.SDK.dataset?.status?.id === 'failed') {
+        } else if (store.SDK.type === 'DE' && datasetStatusID === 'failed') {
           return (
             <Block name="syncInProgress">
               <Elem name='title' tag="h3">Failed to sync data</Elem>
@@ -184,7 +187,7 @@ export const DataView = injector(
 
         return content;
       },
-      [hasData, isLabeling, isLoading, total],
+      [hasData, isLabeling, isLoading, total, datasetStatusID],
     );
 
     const decorationContent = (col) => {
@@ -319,6 +322,15 @@ export const DataView = injector(
 
       if (highlighted && !highlighted.isSelected) store.startLabeling(highlighted);
     });
+
+    useEffect(() => {
+      const updateDatasetStatus = (dataset) => (
+        dataset?.status?.id && setDatasetStatusID(dataset?.status?.id)
+      );
+
+      getRoot(store).SDK.on("datasetUpdated", updateDatasetStatus);
+      return () => getRoot(store).SDK.off("datasetUpdated", updateDatasetStatus);
+    }, []);
 
     // Render the UI for your table
     return (

--- a/src/components/MainView/DataViewOld/Table.js
+++ b/src/components/MainView/DataViewOld/Table.js
@@ -140,7 +140,7 @@ export const DataView = injector(
               <Spinner size="large" />
             </Block>
           );
-        } else if (store.SDK.type === 'DE' && datasetStatusID === 'failed') {
+        } else if (store.SDK.type === 'DE' && ['canceled', 'failed'].includes(datasetStatusID)) {
           return (
             <Block name="syncInProgress">
               <Elem name='title' tag="h3">Failed to sync data</Elem>
@@ -148,6 +148,13 @@ export const DataView = injector(
               <Button onClick={async () => {
                 window.open('./settings/storage');
               }}>Manage Storage</Button>
+            </Block>
+          );
+        } else if (store.SDK.type === 'DE' && (total === 0 || data.length === 0 || !hasData) && datasetStatusID === 'completed') {
+          return (
+            <Block name="syncInProgress">
+              <Elem name='title' tag="h3">Nothing found</Elem>
+              <Elem name='text'>Try adjusting the filter or semantic search parameters</Elem>
             </Block>
           );
         } else if (store.SDK.type === 'DE' && (total === 0 || data.length === 0 || !hasData)) {

--- a/src/utils/feature-flags.js
+++ b/src/utils/feature-flags.js
@@ -81,6 +81,10 @@ export const FF_LOPS_E_10 = "fflag_feat_front_lops_e_10_updated_ux_short";
  */
 export const FF_OPTIC_2 = "fflag_feat_optic_2_ensure_draft_saved_short";
 
+/**
+ * Adding the ability to toggle dataset storage editability.
+ */
+export const FF_LOPS_86 = "fflag_feat_front_lops_86_datasets_storage_edit_short";
 
 // Customize flags
 const flags = {};


### PR DESCRIPTION
empty state when sync is in failed state should display distinct message and show a message to open storage settings

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance

### This change affects (describe how if yes)
- [ ] Performance
- [ ] Security
- [x] UX - better feedback to user based on dataset sync status

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e (codecept)
- [ ] integration (cypress)
- [ ] unit (jest)

### Which logical domain(s) does this change affect?
DataDiscovery data explorer