### PR TITLE
fix: DIA-640: [FE] when creating a new dataset and navigating to it tasks request will fire multiple times

### DIFF
--- a/src/stores/Tabs/store.js
+++ b/src/stores/Tabs/store.js
@@ -269,7 +269,7 @@ export const TabStore = types
       // so we need to take in from the list once again
       defaultView = self.views[self.views.length - 1];
       self.selected = defaultView;
-      defaultView.reload();
+      getRoot(self).SDK.hasInterface('tabs') && defaultView.reload();
     }),
 
     snapshotFromUrl(viewQueryParam) {
@@ -316,7 +316,7 @@ export const TabStore = types
         self.views.push({ ...newViewSnapshot, saved: true });
         const newView = self.views[self.views.length - 1];
 
-        newView.reload();
+        root.SDK.hasInterface('tabs') && newView.reload();
         self.setSelected(newView);
         destroy(view);
 


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
since Data Explorer doesnt uses the tabs interface having default view creation and new view creation calling reload only caused the tasks endpoint to fire more times than needed leading to extra load at dataset creation
