### PR TITLE
fix: DIA-736: [FE] disable add to project actions when dataset sync is not complete

### DIFF
--- a/src/components/DataManager/Toolbar/ActionsButton.js
+++ b/src/components/DataManager/Toolbar/ActionsButton.js
@@ -88,12 +88,13 @@ export const ActionsButton = injector(observer(({ store, size, hasSelected, ...r
           isSeparator: action.isSeparator,
           isTitle: action.isTitle,
           danger: isDeleteAction,
+          disabled: action.disabled,
         }}
         name='actionButton'
       >
-        <Elem name='titleContainer'>
+        <Elem name='titleContainer' {...(action.disabled ? { title: action.disabledReason } : {})}>
           <Elem name='title'>{action.title}</Elem>
-          {hasChildren ? <Elem name='icon' tag={FaChevronRight} /> : null}
+          {(hasChildren && !action.disabled) ? <Elem name='icon' tag={FaChevronRight} /> : null}
         </Elem>
       </Block>
     );
@@ -104,7 +105,7 @@ export const ActionsButton = injector(observer(({ store, size, hasSelected, ...r
         align="top-right-outside"
         toggle={false}
         ref={submenuRef}
-        content={<Block name='actionButton-submenu' tag="ul" mod={{ newUI: isNewUI }}>{action.children.map(ActionButton, parentRef)}</Block>}
+        content={<Block name='actionButton-submenu' tag="ul" mod={{ newUI: isNewUI }}>{(!action.disabled) && action.children.map(ActionButton, parentRef)}</Block>}
       >
         {titleContainer}
       </Dropdown.Trigger>  
@@ -125,8 +126,9 @@ export const ActionsButton = injector(observer(({ store, size, hasSelected, ...r
           key={action.id}
           danger={isDeleteAction}
           onClick={onClick}
-          className={`actionButton${action.isSeparator ? "_isSeparator" : (action.isTitle ? "_isTitle" : "")}`}
+          className={`actionButton${action.isSeparator ? "_isSeparator" : (action.isTitle ? "_isTitle" : "")} ${(action.disabled) ? "actionButton_disabled" : ""}`}
           icon={isDeleteAction && <FaTrash />}
+          title={action.disabled ? action.disabledReason : null}
         >
           {action.title}
         </Menu.Item>

--- a/src/components/DataManager/Toolbar/ActionsButton.js
+++ b/src/components/DataManager/Toolbar/ActionsButton.js
@@ -73,6 +73,7 @@ export const ActionsButton = injector(observer(({ store, size, hasSelected, ...r
     const onClick = useCallback((e) => {
       e.preventDefault();
       e.stopPropagation();
+      if (action.disabled) return;
       action?.callback ? action?.callback(store.currentView?.selected?.snapshot, action) : invokeAction(action, isDeleteAction);
       parentRef?.current?.close?.();
     }, [store.currentView?.selected]);
@@ -94,7 +95,7 @@ export const ActionsButton = injector(observer(({ store, size, hasSelected, ...r
       >
         <Elem name='titleContainer' {...(action.disabled ? { title: action.disabledReason } : {})}>
           <Elem name='title'>{action.title}</Elem>
-          {(hasChildren && !action.disabled) ? <Elem name='icon' tag={FaChevronRight} /> : null}
+          {(hasChildren) ? <Elem name='icon' tag={FaChevronRight} /> : null}
         </Elem>
       </Block>
     );
@@ -105,7 +106,7 @@ export const ActionsButton = injector(observer(({ store, size, hasSelected, ...r
         align="top-right-outside"
         toggle={false}
         ref={submenuRef}
-        content={<Block name='actionButton-submenu' tag="ul" mod={{ newUI: isNewUI }}>{(!action.disabled) && action.children.map(ActionButton, parentRef)}</Block>}
+        content={<Block name='actionButton-submenu' tag="ul" mod={{ newUI: isNewUI }}>{action.children.map(ActionButton, parentRef)}</Block>}
       >
         {titleContainer}
       </Dropdown.Trigger>  

--- a/src/components/DataManager/Toolbar/ActionsButton.styl
+++ b/src/components/DataManager/Toolbar/ActionsButton.styl
@@ -50,6 +50,14 @@
       background-color rgba(0,0,0,0.04)
   &_danger
     color #d00
+  &_disabled
+    background-color rgba(0,0,0,0.04)
+    color rgba(0,0,0,0.25)
+    cursor initial
+    &:hover
+      background-color rgba(0,0,0,0.04) !important
+      color rgba(0,0,0,0.25) !important
+      cursor initial
 
 .actionButtonPrime
   gap 8px

--- a/src/stores/Action.js
+++ b/src/stores/Action.js
@@ -59,6 +59,8 @@ export const Action = types.model("Action", {
     isSeparator: types.optional(types.boolean, false),
     isTitle: types.optional(types.boolean, false),
     newStyle: types.optional(types.boolean, false),
+    disabled: types.optional(types.boolean, false),
+    disabledReason: types.optional(types.string, ""),
   } : {}),
 }).volatile(() => ({
   caller: null,


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
we dont want to allow export to project until sync is completed, but we do want to visualize the item with an indication of why its disabled