### PR TITLE
fix: DIA-754: [FE] Search option does not reflect actual queries state

### DIFF
--- a/src/mixins/DataStore/DataStore.js
+++ b/src/mixins/DataStore/DataStore.js
@@ -181,12 +181,13 @@ export const DataStore = (
       fetch: flow(function* ({ id, query, pageNumber = null, reload = false, interaction, pageSize } = {}) {
         let currentViewId, currentViewQuery;
         const requestId = self.requestId = guidGenerator();
+        const root = getRoot(self);
 
         if (id) {
           currentViewId = id;
           currentViewQuery = query;
         } else {
-          const currentView = getRoot(self).viewsStore.selected;
+          const currentView = root.viewsStore.selected;
 
           currentViewId = currentView?.id;
           currentViewQuery = currentView?.virtual ? currentView?.query : null;
@@ -226,10 +227,10 @@ export const DataStore = (
 
         if (interaction) Object.assign(params, { interaction });
 
-        const data = yield getRoot(self).apiCall(apiMethod, params);
+        const data = yield root.apiCall(apiMethod, params, {}, { allowCancel: root.SDK.type === 'DE' });
 
         // We cancel current request processing if request id
-        // cnhaged during the request. It indicates that something
+        // changed during the request. It indicates that something
         // triggered another request while current one is not yet finished
         if (requestId !== self.requestId || data.isCancelled) {
           console.log(`Request ${requestId} was cancelled by another request`);
@@ -237,7 +238,7 @@ export const DataStore = (
         }
 
         const highlightedID = self.highlighted;
-        const apiMethodSettings = getRoot(self).API.getSettingsByMethodName(apiMethod);
+        const apiMethodSettings = root.API.getSettingsByMethodName(apiMethod);
         const { total, [apiMethod]: list } = data;
         let associatedList = [];
 
@@ -260,7 +261,7 @@ export const DataStore = (
 
         self.loading = false;
 
-        getRoot(self).SDK.invoke('dataFetched', self);
+        root.SDK.invoke('dataFetched', self);
       }),
 
       reload: flow(function* ({ id, query, interaction } = {}) {

--- a/src/mixins/DataStore/DataStore.js
+++ b/src/mixins/DataStore/DataStore.js
@@ -232,7 +232,7 @@ export const DataStore = (
         // We cancel current request processing if request id
         // changed during the request. It indicates that something
         // triggered another request while current one is not yet finished
-        if (requestId !== self.requestId || data.isCancelled) {
+        if (requestId !== self.requestId || data.isCanceled) {
           console.log(`Request ${requestId} was cancelled by another request`);
           return;
         }

--- a/src/mixins/DataStore/DataStore.js
+++ b/src/mixins/DataStore/DataStore.js
@@ -227,7 +227,7 @@ export const DataStore = (
 
         if (interaction) Object.assign(params, { interaction });
 
-        const data = yield root.apiCall(apiMethod, params, {}, { allowCancel: root.SDK.type === 'DE' });
+        const data = yield root.apiCall(apiMethod, params, {}, { allowToCancel: root.SDK.type === 'DE' });
 
         // We cancel current request processing if request id
         // changed during the request. It indicates that something

--- a/src/mixins/DataStore/DataStore.js
+++ b/src/mixins/DataStore/DataStore.js
@@ -231,7 +231,7 @@ export const DataStore = (
         // We cancel current request processing if request id
         // cnhaged during the request. It indicates that something
         // triggered another request while current one is not yet finished
-        if (requestId !== self.requestId) {
+        if (requestId !== self.requestId || data.isCancelled) {
           console.log(`Request ${requestId} was cancelled by another request`);
           return;
         }

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -542,27 +542,33 @@ export const AppStore = types
      * @param {string} methodName one of the methods in api-config
      * @param {object} params url vars and query string params
      * @param {object} body for POST/PATCH requests
-     * @param {{ errorHandler?: fn }} [options] additional options like errorHandler
+     * @param {{ errorHandler?: fn, headers?: object, allowCancel?: boolean }} [options] additional options like errorHandler
      */
     apiCall: flow(function* (methodName, params, body, options) {
+      const isAllowCancel = options?.allowCancel;
       const controller = new AbortController();
       const signal = controller.signal;
       const apiTransform = self.SDK.apiTransform?.[methodName];
       const requestParams = apiTransform?.params?.(params) ?? params ?? {};
       const requestBody = apiTransform?.body?.(body) ?? body ?? {};
-      const requestHeaders = { signal, ...(apiTransform?.headers?.(options?.headers) ?? options?.headers ?? {}) };
+      const requestHeaders = apiTransform?.headers?.(options?.headers) ?? options?.headers ?? {};
       const requestKey = `${methodName}_${JSON.stringify(params || {})}`;
       
-      if (self.requestsInFlight.has(requestKey)) {
-        /* if already in flight cancel the first in favor of new one */
-        self.requestsInFlight.get(requestKey).abort();
-        console.log(`Request ${requestKey} canceled`);
+      if (isAllowCancel) {
+        requestHeaders.signal = signal;
+        if (self.requestsInFlight.has(requestKey)) {
+          /* if already in flight cancel the first in favor of new one */
+          self.requestsInFlight.get(requestKey).abort();
+          console.log(`Request ${requestKey} canceled`);
+        }
+        self.requestsInFlight.set(requestKey, controller);
       }
-      self.requestsInFlight.set(requestKey, controller);
       let result = yield self.API[methodName](requestParams, { headers: requestHeaders, body: requestBody.body ?? requestBody });
 
-      result.isCanceled = signal.aborted;
-      self.requestsInFlight.delete(requestKey);
+      if (isAllowCancel) {
+        result.isCanceled = signal.aborted;
+        self.requestsInFlight.delete(requestKey);
+      }
       if (result.error && result.status !== 404 && !signal.aborted) {
         if (options?.errorHandler?.(result)) {
           return result;

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -542,10 +542,10 @@ export const AppStore = types
      * @param {string} methodName one of the methods in api-config
      * @param {object} params url vars and query string params
      * @param {object} body for POST/PATCH requests
-     * @param {{ errorHandler?: fn, headers?: object, allowCancel?: boolean }} [options] additional options like errorHandler
+     * @param {{ errorHandler?: fn, headers?: object, allowToCancel?: boolean }} [options] additional options like errorHandler
      */
     apiCall: flow(function* (methodName, params, body, options) {
-      const isAllowCancel = options?.allowCancel;
+      const isAllowCancel = options?.allowToCancel;
       const controller = new AbortController();
       const signal = controller.signal;
       const apiTransform = self.SDK.apiTransform?.[methodName];

--- a/src/stores/Tabs/store.js
+++ b/src/stores/Tabs/store.js
@@ -302,7 +302,7 @@ export const TabStore = types
       const apiMethod =
         !view.saved && root.apiVersion === 2 ? "createTab" : "updateTab";
 
-      const result = yield root.apiCall(apiMethod, params, body, { allowCancel: root.SDK.type === 'DE' });
+      const result = yield root.apiCall(apiMethod, params, body, { allowToCancel: root.SDK.type === 'DE' });
 
       if (result.isCanceled) {
         view.unlock();

--- a/src/stores/Tabs/store.js
+++ b/src/stores/Tabs/store.js
@@ -302,7 +302,7 @@ export const TabStore = types
       const apiMethod =
         !view.saved && root.apiVersion === 2 ? "createTab" : "updateTab";
 
-      const result = yield root.apiCall(apiMethod, params, body);
+      const result = yield root.apiCall(apiMethod, params, body, { allowCancel: root.SDK.type === 'DE' });
 
       if (result.isCanceled) {
         view.unlock();

--- a/src/stores/Tabs/store.js
+++ b/src/stores/Tabs/store.js
@@ -303,6 +303,11 @@ export const TabStore = types
         !view.saved && root.apiVersion === 2 ? "createTab" : "updateTab";
 
       const result = yield root.apiCall(apiMethod, params, body);
+
+      if (result.isCanceled) {
+        view.unlock();
+        return view;
+      }
       const viewSnapshot = getSnapshot(view);
       const newViewSnapshot = {
         ...viewSnapshot,

--- a/src/stores/Tabs/store.js
+++ b/src/stores/Tabs/store.js
@@ -305,7 +305,6 @@ export const TabStore = types
       const result = yield root.apiCall(apiMethod, params, body, { allowToCancel: root.SDK.type === 'DE' });
 
       if (result.isCanceled) {
-        view.unlock();
         return view;
       }
       const viewSnapshot = getSnapshot(view);

--- a/src/stores/Tabs/tab.js
+++ b/src/stores/Tabs/tab.js
@@ -396,7 +396,7 @@ export const Tab = types
       }
       if (self.virtual) {
         yield self.dataStore.reload({ query: self.query, interaction });
-      } else if (isFF(FF_LOPS_12) && self.root.SDK.type === 'labelops') {
+      } else if (isFF(FF_LOPS_12) && self.root.SDK?.type === 'labelops') {
         yield self.dataStore.reload({ query: self.query, interaction });
       }
 
@@ -439,7 +439,7 @@ export const Tab = types
 
           History.navigate({ tab: self.key }, true);
           self.reload({ interaction });
-        } else if (isFF(FF_LOPS_12) && self.root.SDK.type === 'labelops') {
+        } else if (isFF(FF_LOPS_12) && self.root.SDK?.type === 'labelops') {
           const snapshot = self.serialize();
 
           self.key = self.parent.snapshotToUrl(snapshot);

--- a/src/stores/Tabs/tab.js
+++ b/src/stores/Tabs/tab.js
@@ -400,7 +400,7 @@ export const Tab = types
         yield self.dataStore.reload({ query: self.query, interaction });
       }
 
-      getRoot(self).SDK.invoke("tabReloaded", self);
+      getRoot(self).SDK?.invoke?.("tabReloaded", self);
     }),
 
     deleteFilter(filter) {

--- a/src/utils/api-proxy/index.js
+++ b/src/utils/api-proxy/index.js
@@ -248,7 +248,7 @@ export class APIProxy {
           rawResponse = await fetch(apiCallURL, requestParams);
         }
 
-        if (raw) return rawResponse;
+        if (raw || rawResponse.isCanceled) return rawResponse;
 
         responseMeta = {
           headers: new Map(Array.from(rawResponse.headers)),


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
api requests can now check if request is already in flight - if already in flight cancel first promise and use the new one. this prevents a race condition where second request resolves before the first causing the first to override changes applied by the second (where second one has the correct outcome due to having more up to date params)