### PR TITLE
fix: OPTIC-152: Uploading a text field but only 'true' is showing up not 'false'

### DIFF
--- a/src/components/CellViews/DateTimeCell.js
+++ b/src/components/CellViews/DateTimeCell.js
@@ -1,12 +1,12 @@
 import { format, isValid } from "date-fns";
+export const dateTimeFormat = "MMM dd yyyy, HH:mm:ss";
 
 export const DateTimeCell = (column) => {
   const date = new Date(column.value);
-  const dateFormat = "MMM dd yyyy, HH:mm:ss";
 
   return column.value ? (
     <div style={{ whiteSpace: "nowrap" }}>
-      {isValid(date) ? format(date, dateFormat) : ""}
+      {isValid(date) ? format(date, dateTimeFormat) : ""}
     </div>
   ) : (
     ""

--- a/src/components/CellViews/StringCell.js
+++ b/src/components/CellViews/StringCell.js
@@ -4,7 +4,8 @@ const valueToString = (value) => {
   try {
     return JSON.stringify(value);
   } catch {
-    return value.toString();
+    /* if undefined or null we'll treat it as empty string, otherwise toString(), this will allow 0 and false to render properly */
+    return (value ?? "").toString();
   }
 };
 
@@ -18,7 +19,7 @@ export const StringCell = ({ value }) => {
         lineHeight: "16px",
       }}
     >
-      {value ? valueToString(value) : ""}
+      {valueToString(value)}
     </div>
   );
 };

--- a/src/components/CellViews/StringCell.js
+++ b/src/components/CellViews/StringCell.js
@@ -12,15 +12,15 @@ const valueToString = (value) => {
 };
 
 export const StringCell = ({ value }) => {
+  const style = {
+    maxHeight: "100%",
+    overflow: "hidden",
+    fontSize: 12,
+    lineHeight: "16px",
+  };
+
   return (
-    <div
-      style={{
-        maxHeight: "100%",
-        overflow: "hidden",
-        fontSize: 12,
-        lineHeight: "16px",
-      }}
-    >
+    <div style={style}>
       {valueToString(value)}
     </div>
   );

--- a/src/components/CellViews/StringCell.js
+++ b/src/components/CellViews/StringCell.js
@@ -1,7 +1,11 @@
-const valueToString = (value) => {
+import { format, isValid } from "date-fns";
+import { dateTimeFormat } from "./DateTimeCell";
+
+export const valueToString = (value) => {
   if (typeof value === "string") return value;
   /* if undefined or null we'll treat it as empty string */
   if (value === undefined || value === null) return "";
+  if (value instanceof Date && isValid(value)) return format(value, dateTimeFormat);
 
   try {
     /* JSON.stringify will handle JSON and non-strings, non-null, non-undefined */

--- a/src/components/CellViews/StringCell.js
+++ b/src/components/CellViews/StringCell.js
@@ -1,11 +1,13 @@
 const valueToString = (value) => {
   if (typeof value === "string") return value;
+  /* if undefined or null we'll treat it as empty string */
+  if (value === undefined || value === null) return "";
 
   try {
+    /* JSON.stringify will handle JSON and non-strings, non-null, non-undefined */
     return JSON.stringify(value);
   } catch {
-    /* if undefined or null we'll treat it as empty string, otherwise toString(), this will allow 0 and false to render properly */
-    return (value ?? "").toString();
+    return 'Error: Invalid JSON';
   }
 };
 


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
there was an issue where all falsey values would be treated as empty string, which is undesired. this change makes it so 0 and false will render as expected but null and undefined will be treated as empty string