### PR TITLE
fix: LEAP-443: Support small changes in LSF

### DIFF
--- a/src/components/Label/Toolbar/Toolbar.js
+++ b/src/components/Label/Toolbar/Toolbar.js
@@ -27,10 +27,7 @@ export const Toolbar = observer(({ view, history, lsf, isLabelStream, hasInstruc
 
   const task = view.dataStore.selected;
 
-  const { viewingAllAnnotations, viewingAllPredictions } =
-    lsf?.annotationStore ?? {};
-
-  const viewAll = viewingAllAnnotations || viewingAllPredictions;
+  const { viewingAll: viewAll } = lsf?.annotationStore ?? {};
 
   return lsf?.noTask === false && task ? (
     <Block name="label-toolbar" mod={{ labelStream: isLabelStream }}>

--- a/src/sdk/dm-sdk.js
+++ b/src/sdk/dm-sdk.js
@@ -33,7 +33,6 @@
  * interfaces: Dict<boolean>,
  * instruments: Dict<any>,
  * toolbar?: string,
- * panels?: Record<string, any>[]
  * spinner?: import("react").ReactNode
  * apiTransform?: Record<string, Record<string, Function>
  * tabControls?: { add?: boolean, delete?: boolean, edit?: boolean, duplicate?: boolean },
@@ -159,7 +158,6 @@ export class DataManager {
     this.showPreviews = config.showPreviews ?? false;
     this.polling = config.polling;
     this.toolbar = config.toolbar ?? DEFAULT_TOOLBAR;
-    this.panels = config.panels;
     this.spinner = config.spinner;
     this.spinnerSize = config.spinnerSize;
     this.instruments = prepareInstruments(config.instruments ?? {});

--- a/src/sdk/lsf-sdk.js
+++ b/src/sdk/lsf-sdk.js
@@ -15,7 +15,6 @@
 import {
   FF_DEV_1752,
   FF_DEV_2186,
-  FF_DEV_2715,
   FF_DEV_2887,
   FF_DEV_3034,
   FF_DEV_3734,
@@ -163,8 +162,6 @@ export class LSFWrapper {
     const queuePosition = queueDone ? queueDone + 1 : queueLeft ? queueTotal - queueLeft + 1 : 1;
 
     const lsfProperties = {
-      // ensure that we are able to distinguish at component level if the app has fully hydrated.
-      hydrated: false,
       user: options.user,
       config: this.lsfConfig,
       task: taskToLSFormat(this.task),
@@ -377,13 +374,6 @@ export class LSFWrapper {
     this.lsf.initializeStore(lsfTask);
     this.setAnnotation(annotationID, fromHistory || isRejectedQueue);
     this.setLoading(false);
-    if (isFF(FF_DEV_2715)) {
-      this.setHydrated(true);
-    }
-  }
-
-  setHydrated(value) {
-    this.lsf.setHydrated?.(value);
   }
 
   /** @private */

--- a/src/sdk/lsf-sdk.js
+++ b/src/sdk/lsf-sdk.js
@@ -195,7 +195,6 @@ export class LSFWrapper {
       onSelectAnnotation: this.onSelectAnnotation,
       onNextTask: this.onNextTask,
       onPrevTask: this.onPrevTask,
-      panels: this.datamanager.panels,
     };
 
     this.initLabelStudio(lsfProperties);


### PR DESCRIPTION
Mirroring changes to LSF:
- Remove `viewingAllPredictions`
- Remove `panels`
- Remove `hydrated`

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance

### Describe the reason for change
Those properties are removed in LSF, so we have to remove their usage

### This change affects (describe how if yes)
- [ ] Performance
- [ ] Security
- [ ] UX

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e (codecept)
- [ ] integration (cypress)
- [ ] unit (jest)
